### PR TITLE
fix: align Docker build context for API across all environments

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -22,9 +22,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build API image
-        run: |
-          cd api
-          docker build -t bgc-api:scan .
+        run: docker build -f api/Dockerfile -t bgc-api:scan .
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master

--- a/k8s/README-K8s.md
+++ b/k8s/README-K8s.md
@@ -25,8 +25,7 @@ Senha do app bgc: Secret pg-postgresql chave password.
 ## 3 Build & Import Images
 
 # API
-cd .\api
-docker build -t bgc-api:v0.2.5 .
+docker build -f api/Dockerfile -t bgc-api:v0.2.5 .
 k3d image import -c bgc bgc-api:v0.2.5
 
 # Web

--- a/scripts/k8s.ps1
+++ b/scripts/k8s.ps1
@@ -53,7 +53,7 @@ function Test-ClusterExists {
 
 function Build-Images {
     Write-Host "🔨 Building Docker images..." -ForegroundColor Yellow
-    docker build -t bgc/bgc-api:dev api/
+    docker build -f api/Dockerfile -t bgc/bgc-api:dev .
     docker build -t bgc/bgc-web:latest web-next/
     Write-Host "✅ Images built!" -ForegroundColor Green
 }


### PR DESCRIPTION
Fixes Docker build error "schemas: not found" in GitHub Actions by aligning the build context across all environments to match the working docker-compose configuration.

## Changes
- .github/workflows/security-scan.yml: Use root context with -f api/Dockerfile
- scripts/k8s.ps1: Fix K8s build to use correct context
- k8s/README-K8s.md: Update documentation with correct build command

## Root Cause
The api/Dockerfile was designed to use the project root as build context (evidenced by COPY api/... patterns), but GitHub Actions and K8s scripts were using api/ as context, preventing access to the schemas/ directory required at line 27 of the Dockerfile.

## Impact
- ✅ GitHub Actions security-scan workflow now builds successfully
- ✅ Kubernetes local builds (make k8s-build) now work correctly
- ✅ All build methods now consistent with docker-compose.yml
- ✅ Zero impact on runtime or existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)