### PR TITLE
fix: prevent TruffleHog failure when BASE and HEAD commits are identical

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -120,6 +120,7 @@ jobs:
           fetch-depth: 0  # Full history for better detection
 
       - name: TruffleHog Secret Scan
+        if: github.event.before != github.sha
         uses: trufflesecurity/trufflehog@main
         with:
           path: ./


### PR DESCRIPTION
Adds conditional to skip TruffleHog secret scan when there are no new commits to scan (BASE == HEAD). This prevents workflow failures on direct pushes to the default branch where the commit range is empty.

The condition `github.event.before != github.sha` ensures TruffleHog only runs when there are actual changes to scan.

Fixes: TruffleHog exit error when BASE and HEAD are the same

🤖 Generated with [Claude Code](https://claude.com/claude-code)